### PR TITLE
Fix some documentation errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,14 @@ function preloader() {
   return <img src="spinner.gif" />;
 }
 
+function wrapper() {
+  return <div />;
+}
+
 React.render((
   <ImageLoader
     src="/path/to/image.jpg"
-    wrapper={div}
+    wrapper={wrapper}
     preloader={preloader}>
     Image load failed!
   </ImageLoader>
@@ -41,7 +45,8 @@ Props
 Name        | Type     | Description
 ------------|----------|------------
 `src`       | string   | The URL of the image to be loaded.
-`preloader` | function | An optional React component class or function that returns a React element to be shown while the image loads.
+`wrapper`   | function | An optional function that returns a React element to wrap the ImageLoader in.
+`preloader` | function | An optional function that returns a React element to be shown while the image loads.
 `onLoad`    | function | An optional handler for the [load] event.
 `onError`   | function | An optional handler for the [error] event.
 `wrapper`   | function | A React component class or function that returns a React element to be used as the wrapper component. Defaults to `React.DOM.span`.


### PR DESCRIPTION
Properly define and document the wrapper function (as required in the proptypes).

"preloader" prop only accepts a function, not a React component (as required in proptypes).