### PR TITLE
Cancels pending image request when destroyed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,6 +73,7 @@ export default class ImageLoader extends React.Component {
 
   destroyLoader() {
     if (this.img) {
+      this.img.src = '';
       this.img.onload = null;
       this.img.onerror = null;
       this.img = null;


### PR DESCRIPTION
If you mount multiple imageloaders and unmount them before the browser initiated the request, the browser will still try complete pending requests.
Setting the src to '' causes them to abort the pending image requests.
