### PR TITLE
add image dimensions pass to wrapper function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -80,8 +80,9 @@ export default class ImageLoader extends React.Component {
   }
 
   handleLoad(event) {
+    const { naturalWidth, naturalHeight } = event.target; 
     this.destroyLoader();
-    this.setState({status: Status.LOADED});
+    this.setState({ status: Status.LOADED, width: naturalWidth, height: naturalHeight });
 
     if (this.props.onLoad) this.props.onLoad(event);
   }
@@ -107,8 +108,11 @@ export default class ImageLoader extends React.Component {
   }
 
   render() {
+    const { width, height } = this.state;
     let wrapperProps = {
-      className: this.getClassName(),
+      width,
+      height,
+      className: this.getClassName()
     };
 
     if (this.props.style) {


### PR DESCRIPTION
Loaded image width and height are passed as props of the first argument passed to `props.wrapper` function. Useful if you want to set image wrapper element dimensions.